### PR TITLE
Created tests for TryParseMessage method of MessageReaderWriter

### DIFF
--- a/src/Pubbie/MessageReaderWriter.cs
+++ b/src/Pubbie/MessageReaderWriter.cs
@@ -61,10 +61,15 @@ namespace Pubbie
                 var payload = input.Slice(reader.Position, length);
                 message.Payload = payload.IsSingleSegment ? payload.First : payload.ToArray();
                 reader.Advance(length);
-            }
 
-            consumed = reader.Position;
-            examined = consumed;
+                consumed = reader.Position;
+                examined = consumed;
+            }
+            else
+            {
+                consumed = reader.Position;
+                examined = input.End;
+            }
 
             return true;
         }


### PR DESCRIPTION
I've also updated returned value of `SequencePosition examined` when payload is missing.

I'm not convinced about the behavior around the optional payload, doesn't it create a problem not being able to tell if those extra bytes are an incomplete `length` of the payload or part of the next message?

Currently if you have less then 4 bytes after the topic, it would parse successfully without a payload.
But, if you have at least for bytes, it would consider those as length of the payload, then fail if there are not enough bytes based on this length.

I would suggest determining if we should have a payload, based on the type of the message.

That do you think?

Thank you!